### PR TITLE
Let wp::command have conditions so that theme execs don't run all the time

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -1,7 +1,9 @@
 define wp::command (
   $location,
   $command,
-  $user = $::wp::user
+  $user = $::wp::user,
+  $onlyif = '/usr/bin/wp core is-installed',
+  $unless = undef,
 ) {
   include wp::cli
 
@@ -10,6 +12,7 @@ define wp::command (
     cwd     => $location,
     user    => $user,
     require => [ Class['wp::cli'] ],
-    onlyif  => '/usr/bin/wp core is-installed'
+    onlyif  => $onlyif,
+    unless  => $unless,
   }
 }

--- a/manifests/theme.pp
+++ b/manifests/theme.pp
@@ -22,10 +22,12 @@ define wp::theme (
   case $ensure {
     enabled: {
       $command = "activate ${theme_name}"
+      $check = "/usr/bin/wp theme status ${theme_name} | grep -q Status:\\ Active"
     }
     installed: {
       # this is just something to do if we don't want to activate theme
       $command = "is-installed ${theme_name}"
+      $check = "/usr/bin/wp theme ${command}"
     }
     default: {
       fail('Invalid ensure for wp::theme')
@@ -34,6 +36,7 @@ define wp::theme (
   wp::command { "${location} theme ${command}":
     location => $location,
     command  => "theme ${command}",
-    user     => $user
+    user     => $user,
+    unless   => $check,
   }
 }


### PR DESCRIPTION
theme.pp uses wp::command to activate themes and the command was executing on every puppet run even though no changes were being made.